### PR TITLE
Add random/concentrated bombardment, enhanced guns, new monster rewards, and related mechanics

### DIFF
--- a/index.html
+++ b/index.html
@@ -105,6 +105,8 @@ SOFTWARE. -->
   <option value="bombard" data-anyisland="true">砲撃 (120G)</option>
   <option value="spreadBombard" data-anyisland="true">拡散弾砲撃 (500G)</option>
   <option value="ppBombard" data-anyisland="true">PP弾砲撃 (10000000G)</option>
+  <option value="randomBombard" data-anyisland="true">ランダム弾砲撃 (500000G)</option>
+  <option value="concentratedFire" data-myisland="true">集中砲撃</option>
   <option value="selfDestructMilitaryFacility" data-myisland="true">軍事施設自爆 (無料)</option>
   <option value="goToOtherIsland" data-myisland="true">他の島に行く</option>
   <option value="returnToMyIsland" data-anyisland="true">自島に戻る</option>

--- a/script.js
+++ b/script.js
@@ -1,10 +1,13 @@
 let monster = null;
 const MONSTER_TYPES = {
-  1: { name: '怪獣シマオロシ', minHP: 1, maxHP: 1, ability: null, condition: (pop) => pop >= 60000 },
-  2: { name: '怪獣ヴォルカガロス', minHP: 2, maxHP: 4, ability: 'destroyArea', condition: (pop) => pop >= 120000 },
-  3: { name: '怪獣アエロガロス', minHP: 3, maxHP: 3, ability: 'multiMove', condition: (pop) => pop >= 120000 },
-  4: { name: '怪獣テラガロス', minHP: 5, maxHP: 5, ability: 'landfillSea', condition: (pop) => pop >= 150000 },
-  5: { name: '怪獣アクアガロス', minHP: 3, maxHP: 5, ability: 'createSea', condition: (pop) => pop >= 150000 }
+  1: { name: '怪獣シマオロシ', minHP: 1, maxHP: 1, ability: null, moneyPerTurn: 0, defeatMoney: 0, condition: (pop, currentTurn) => pop >= 60000 },
+  2: { name: '怪獣ヴォルカガロス', minHP: 2, maxHP: 4, ability: 'destroyArea', moneyPerTurn: 0, defeatMoney: 0, condition: (pop, currentTurn) => pop >= 120000 },
+  3: { name: '怪獣アエロガロス', minHP: 3, maxHP: 3, ability: 'multiMove', moneyPerTurn: 0, defeatMoney: 0, condition: (pop, currentTurn) => pop >= 120000 },
+  4: { name: '怪獣テラガロス', minHP: 5, maxHP: 5, ability: 'landfillSea', moneyPerTurn: 0, defeatMoney: 0, condition: (pop, currentTurn) => pop >= 150000 },
+  5: { name: '怪獣アクアガロス', minHP: 3, maxHP: 5, ability: 'createSea', moneyPerTurn: 0, defeatMoney: 0, condition: (pop, currentTurn) => pop >= 150000 },
+  6: { name: 'シルバガロス', minHP: 2, maxHP: 2, ability: null, moneyPerTurn: 5000, defeatMoney: 5000000, condition: (pop, currentTurn) => pop >= 100000 && currentTurn >= 3000 },
+  7: { name: 'ゴルドガロス', minHP: 2, maxHP: 2, ability: null, moneyPerTurn: 50000, defeatMoney: 50000000, condition: (pop, currentTurn) => pop >= 130000 && currentTurn >= 3000 },
+  8: { name: 'プラチガロス', minHP: 2, maxHP: 2, ability: null, moneyPerTurn: 500000, defeatMoney: 250000000, condition: (pop, currentTurn) => pop >= 150000 && currentTurn >= 3000 }
 };
   const SIZE = 16;
   let money = 2500;
@@ -102,7 +105,7 @@ function getActionName(action, x, y, extraData) {
         buildFarm: '農場建設', buildFactory: '工場建設', enhanceFacility: '設備強化', buildPort: '港建設',
         buildGun: '砲台建設', buildDefenseFacility: '防衛施設建設', flatten: '整地', landfill: '埋め立て',
         dig: '掘削', cutForest: '伐採', plantForest: '植林', exportFood: '食料輸出',
-        bombard: '砲撃', spreadBombard: '拡散弾砲撃', ppBombard: 'PP弾砲撃', selfDestructMilitaryFacility: '軍事施設自爆',
+        bombard: '砲撃', spreadBombard: '拡散弾砲撃', ppBombard: 'PP弾砲撃', randomBombard: 'ランダム弾砲撃', concentratedFire: '集中砲撃', selfDestructMilitaryFacility: '軍事施設自爆',
         goToOtherIsland: '他の島に行く', returnToMyIsland: '自島に戻る', buildWarship: '軍艦建造',
         refuelWarship: '燃料補給', resupplyWarshipAmmo: '弾薬補給', repairWarship: '軍艦修理',
         enhanceWarship: '軍艦増強', decommissionWarship: '軍艦除籍', dispatchWarship: '軍艦派遣',
@@ -114,7 +117,7 @@ function getActionName(action, x, y, extraData) {
     // 計画の詳細情報を名前に組み込む
     if (action === 'exportFood' && extraData && extraData.amount) {
         name += ` (${extraData.amount * 20} 食料)`;
-    } else if ((action === 'bombard' || action === 'spreadBombard' || action === 'ppBombard') && extraData && extraData.count) {
+    } else if ((action === 'bombard' || action === 'spreadBombard' || action === 'ppBombard' || action === 'randomBombard') && extraData && extraData.count) {
         name += ` (${extraData.count} 発)`;
     } else if (action === 'refuelWarship' && extraData && extraData.amount) {
         name += ` (${extraData.amount} 燃料)`;
@@ -138,6 +141,14 @@ function getActionName(action, x, y, extraData) {
     let coord = (x !== null && y !== null) ? `(${x},${y})` : '';
 
     return { name, coord };
+}
+
+function getBombardTypeLabel(action) {
+    if (action === 'bombard') return '砲撃';
+    if (action === 'spreadBombard') return '拡散弾砲撃';
+    if (action === 'ppBombard') return 'PP弾砲撃';
+    if (action === 'randomBombard') return 'ランダム弾砲撃';
+    return '砲撃';
 }
 
 // 計画キューの表示を更新する関数
@@ -234,16 +245,28 @@ function getGunCount() {
 
     if (targetMap.length === 0) return 0;
 
-    // mapを走査して砲台 (facility: 'gun') の数を数える
+    // mapを走査して砲台 (facility: 'gun') の砲撃可能数を数える
     let count = 0;
     targetMap.forEach(row => {
         row.forEach(tile => {
             if (tile.facility === 'gun') {
-                count++;
+                count += tile.enhanced ? 3 : 1; // 高効率砲台は3連装
             }
         });
     });
     return count;
+}
+
+function handleMonsterDefeat(monster, customMessage) {
+    const monsterType = MONSTER_TYPES[monster.typeId] || { name: '怪獣', defeatMoney: 0 };
+    monsters = monsters.filter(m => m !== monster);
+    if (customMessage) {
+        logAction(customMessage);
+    }
+    if (monsterType.defeatMoney && monsterType.defeatMoney > 0) {
+        money += monsterType.defeatMoney;
+        logAction(`${monsterType.name}の討伐報奨金として${monsterType.defeatMoney}Gを獲得しました！`);
+    }
 }
 function initMap() {
   map = Array.from({ length: SIZE }, (_, y) =>
@@ -369,7 +392,7 @@ window.updateConfirmButton = function () {
   }
   if (action === 'exportFood') {
       document.getElementById('exportAmount').style.display = 'inline-block';
-  } else if (action === 'bombard' || action === 'spreadBombard' || action === 'ppBombard') {
+  } else if (action === 'bombard' || action === 'spreadBombard' || action === 'ppBombard' || action === 'randomBombard') {
       document.getElementById('bombardCount').style.display = 'inline-block';
   } else if (action === 'goToOtherIsland' || action === 'dispatchWarship') {
       document.getElementById('touristCodeInput').style.display = 'inline-block';
@@ -494,6 +517,7 @@ function showTileInfo(x, y) {
         if (tile.facility === 'farm') facilityName = '強化農場';
         if (tile.facility === 'factory') facilityName = '強化工場';
         if (tile.facility === 'oilRig') facilityName = '高効率海底油田';
+        if (tile.facility === 'gun') facilityName = '高効率砲台';
     }
     info += ` / 建物: ${facilityName}`;
     if (tile.facility === 'house' && !isViewingOtherIsland) info += ` (人口: ${tile.pop})`; // 他の島では人口表示なし
@@ -964,8 +988,7 @@ function handleWarshipAttacks() {
                     monsterHit.hp -= 1; // ダメージ
                     
                     if (monsterHit.hp <= 0) {
-                        monsters = monsters.filter(m => m !== monsterHit); // 配列から削除
-                        logAction(`${warship.name} は ${targetType} を討伐し、${expGained} EXPを獲得しました！`);
+                        handleMonsterDefeat(monsterHit, `${warship.name} は ${targetType} を討伐し、${expGained} EXPを獲得しました！`);
                     } else {
                         logAction(`${warship.name} は ${targetType} に命中！ (残り体力: ${monsterHit.hp})`);
                     }
@@ -1063,8 +1086,8 @@ window.confirmAction = function () {
     }
 const keepOptionSelected = document.getElementById('keepOptionSelected').checked;
   if (isViewingOtherIsland) {
-      if (action === 'bombard' || action === 'spreadBombard' || action === 'ppBombard') {
-          if (!targetTileSelected) {
+      if (action === 'bombard' || action === 'spreadBombard' || action === 'ppBombard' || action === 'randomBombard') {
+          if (action !== 'randomBombard' && !targetTileSelected) {
               logAction(`砲撃対象のタイルを選択してください`);
               return;
           }
@@ -1085,10 +1108,12 @@ const keepOptionSelected = document.getElementById('keepOptionSelected').checked
           // 行動内容を圧縮・暗号化して他島への行動テキストボックスに出力
           const actionData = {
               type: action,
-              x: selectedX,
-              y: selectedY,
               count: count
           };
+          if (action !== 'randomBombard') {
+              actionData.x = selectedX;
+              actionData.y = selectedY;
+          }
           // 新しいエンコード方式 (btoaとencodeURIComponentを組み合わせる)
           const encodedAction = btoa(encodeURIComponent(JSON.stringify(actionData)));
           document.getElementById('actionForOtherIslandOutput').value = encodedAction;
@@ -1110,7 +1135,7 @@ const keepOptionSelected = document.getElementById('keepOptionSelected').checked
   }
 
   if (!action) return;
-  const requiresTileSelection = ['buildFarm', 'buildFactory', 'buildPort', 'buildGun', 'buildDefenseFacility', 'buildWarship', 'refuelWarship', 'resupplyWarshipAmmo', 'repairWarship', 'dispatchWarship', 'requestWarshipReturn', 'flatten', 'landfill', 'dig', 'cutForest', 'plantForest', 'enhanceFacility', 'selfDestructMilitaryFacility', 'bombard', 'spreadBombard', 'ppBombard'];
+  const requiresTileSelection = ['buildFarm', 'buildFactory', 'buildPort', 'buildGun', 'buildDefenseFacility', 'buildWarship', 'refuelWarship', 'resupplyWarshipAmmo', 'repairWarship', 'dispatchWarship', 'requestWarshipReturn', 'flatten', 'landfill', 'dig', 'cutForest', 'plantForest', 'enhanceFacility', 'selfDestructMilitaryFacility', 'bombard', 'spreadBombard', 'ppBombard', 'concentratedFire'];
   if (requiresTileSelection.includes(action) && !targetTileSelected) {
     logAction(`アクションの対象タイルを選択してください`);
     return;
@@ -1130,7 +1155,7 @@ const keepOptionSelected = document.getElementById('keepOptionSelected').checked
     } else {
       logAction(`食料輸出に失敗しました（輸出数が未指定または無効）`);
     }
-  } else if (action === 'bombard' || action === 'spreadBombard' || action === 'ppBombard') {
+  } else if (action === 'bombard' || action === 'spreadBombard' || action === 'ppBombard' || action === 'randomBombard') {
     const count = parseInt(document.getElementById('bombardCount').value);
     if (isNaN(count) || count <= 0) {
       logAction(`砲撃の数が正しく指定されていません`);
@@ -1145,6 +1170,7 @@ const keepOptionSelected = document.getElementById('keepOptionSelected').checked
     if (action === 'bombard') cost = count * 120;
     else if (action === 'spreadBombard') cost = count * 500;
     else if (action === 'ppBombard') cost = count * 10000000; // PP弾の価格を更新
+    else if (action === 'randomBombard') cost = count * 500000;
 
     if (money < cost) {
       logAction(`砲撃に失敗しました（資金不足）`);
@@ -1154,8 +1180,24 @@ const keepOptionSelected = document.getElementById('keepOptionSelected').checked
       logAction(`砲撃に失敗しました（保有砲台数を超えています）`);
       return;
     }
-    actionQueue.push({ x: selectedX, y: selectedY, action, count });
-    logAction(`(${selectedX},${selectedY}) に ${count}発の${action === 'bombard' ? '砲撃' : action === 'spreadBombard' ? '拡散弾砲撃' : 'PP弾砲撃'}を計画しました`);
+    actionQueue.push({ x: action === 'randomBombard' ? null : selectedX, y: action === 'randomBombard' ? null : selectedY, action, count });
+    if (action === 'randomBombard') {
+      logAction(`${count}発のランダム弾砲撃を計画しました`);
+    } else {
+      logAction(`(${selectedX},${selectedY}) に ${count}発の${getBombardTypeLabel(action)}を計画しました`);
+    }
+  } else if (action === 'concentratedFire') {
+    const latestAction = actionQueue[actionQueue.length - 1];
+    if (latestAction && latestAction.action === 'concentratedFire') {
+      if (actionQueue.length + 2 > MAX_QUEUE_SIZE) {
+        logAction(`計画キューに空きが足りないため、集中砲撃を追加できません。`);
+        return;
+      }
+      actionQueue.push({ x: null, y: null, action: 'delayAction', autoInserted: true });
+      logAction(`集中砲撃の連続を防ぐため、遅延行動を自動挿入しました。`);
+    }
+    actionQueue.push({ x: selectedX, y: selectedY, action: 'concentratedFire' });
+    logAction(`(${selectedX},${selectedY}) に集中砲撃を計画しました`);
   } else if (action === 'selfDestructMilitaryFacility') { // 名称変更
     if (tile && (tile.facility === 'gun' || tile.facility === 'defenseFacility')) {
       actionQueue.push({ x: selectedX, y: selectedY, action });
@@ -1629,8 +1671,9 @@ turn++;
           const jsonString = decodeURIComponent(atob(otherIslandActionCode));
           const incomingAction = JSON.parse(jsonString);
 
-          if ((incomingAction.type === 'bombard' || incomingAction.type === 'spreadBombard' || incomingAction.type === 'ppBombard') &&
-              incomingAction.x !== undefined && incomingAction.y !== undefined && incomingAction.count !== undefined) {
+          if ((incomingAction.type === 'bombard' || incomingAction.type === 'spreadBombard' || incomingAction.type === 'ppBombard' || incomingAction.type === 'randomBombard') &&
+              incomingAction.count !== undefined &&
+              (incomingAction.type === 'randomBombard' || (incomingAction.x !== undefined && incomingAction.y !== undefined))) {
               const { x, y, type, count } = incomingAction;
               let errorRange = 1;
               if (type === 'bombard') {
@@ -1639,30 +1682,39 @@ turn++;
                   errorRange = 2;
               } else if (type === 'ppBombard') {
                   errorRange = 0;
+              } else if (type === 'randomBombard') {
+                  errorRange = 0;
               }
 
-              logAction(`他島から ${count}発の${type === 'bombard' ? '砲撃' : type === 'spreadBombard' ? '拡散弾砲撃' : 'PP弾砲撃'}を受けました！`);
+              logAction(`他島から ${count}発の${getBombardTypeLabel(type)}を受けました！`);
               for (let i = 0; i < count; i++) {
-                  let dx = 0;
-                  let dy = 0;
-                  if (errorRange > 0) {
-                      dx = Math.floor(Math.random() * (2 * errorRange + 1)) - errorRange;
-                      dy = Math.floor(Math.random() * (2 * errorRange + 1)) - errorRange;
+                  let tx = 0;
+                  let ty = 0;
+                  if (type === 'randomBombard') {
+                      tx = Math.floor(Math.random() * SIZE);
+                      ty = Math.floor(Math.random() * SIZE);
+                  } else {
+                      let dx = 0;
+                      let dy = 0;
+                      if (errorRange > 0) {
+                          dx = Math.floor(Math.random() * (2 * errorRange + 1)) - errorRange;
+                          dy = Math.floor(Math.random() * (2 * errorRange + 1)) - errorRange;
+                      }
+                      tx = x + dx;
+                      ty = y + dy;
                   }
-                  const tx = x + dx;
-                  const ty = y + dy;
 
                   if (tx >= 0 && ty >= 0 && tx < SIZE && ty < SIZE) {
                       const protectingFacility = getProtectingDefenseFacility(tx, ty); // 変更点
 
                       if (protectingFacility) { // 防衛施設があった場合
-                          if (type === 'ppBombard') { // PP弾だった場合
+                          if (type === 'ppBombard' || type === 'randomBombard') { // PP弾・ランダム弾だった場合
                               protectingFacility.facility = null; // 防衛施設を破壊
                               protectingFacility.terrain = 'waste'; // 防衛施設の場所を荒地にする
                               protectingFacility.enhanced = false; // 強化状態もリセット
-                              logAction(`(${tx},${ty}) を守っていた防衛施設がPP弾により破壊されました！`);
-                              // その後、PP弾の効果を適用（既存の攻撃ロジックに流れる）
-                          } else { // PP弾でなければ防衛施設が守る
+                              logAction(`(${tx},${ty}) を守っていた防衛施設が${getBombardTypeLabel(type)}により破壊されました！`);
+                              // その後、貫通弾の効果を適用（既存の攻撃ロジックに流れる）
+                          } else { // 貫通弾でなければ防衛施設が守る
                               logAction(`砲撃は防衛施設により無効化されました (${tx},${ty})`);
                               turnTileEffects.push({ x: tx, y: ty, type: 'blue' });
                               continue; // 次の攻撃へ
@@ -1713,14 +1765,13 @@ turn++;
                           target.terrain = 'waste';
                           logAction(`他島からの砲撃により (${tx},${ty}) が破壊されました`);
                       }
-                      const monsterHit = monsters.find(m => m.x === tx && m.y === ty);
+                          const monsterHit = monsters.find(m => m.x === tx && m.y === ty);
                       if (monsterHit) {
                           monsterHit.hp -= 1;
                           const monsterName = MONSTER_TYPES[monsterHit.typeId] ? MONSTER_TYPES[monsterHit.typeId].name : '怪獣';
                           logAction(`他島からの砲撃が ${monsterName} に命中！ (残り体力: ${monsterHit.hp})`);
                           if (monsterHit.hp <= 0) {
-                              monsters = monsters.filter(m => m !== monsterHit);
-                              logAction(`${monsterName} は討伐されました！`);
+                              handleMonsterDefeat(monsterHit, `${monsterName} は討伐されました！`);
                           }
                       }
                   } else {
@@ -1829,6 +1880,7 @@ turn++;
 
   // 行動キューの処理 (最大2つまで実行)
 const ACTIONS_PER_TURN = 2; // 1ターンに実行する計画の数
+let previousExecutedAction = null;
 for (let i = 0; i < ACTIONS_PER_TURN; i++) {
     if (actionQueue.length === 0) {
         break; // キューが空になったら終了
@@ -1889,6 +1941,82 @@ const newWarship = {
         }
     };
     if (action === 'delayAction') {
+        previousExecutedAction = 'delayAction';
+    }
+    else if (action === 'concentratedFire') {
+        if (previousExecutedAction === 'concentratedFire') {
+            logAction(`連続する集中砲撃は無効化されました。`);
+            continue;
+        }
+        const targetX = x;
+        const targetY = y;
+        const availableWarships = warships.filter(ship =>
+            ship.currentDurability > 0 &&
+            !ship.isDispatched &&
+            ship.currentAmmo > 0 &&
+            ship.currentFuel > 0 &&
+            ship.abnormality !== 'fire' &&
+            !(ship.x === targetX && ship.y === targetY)
+        );
+        if (availableWarships.length === 0) {
+            logAction(`(${targetX},${targetY}) への集中砲撃は実行されませんでした（攻撃可能な軍艦がありません）。`);
+            previousExecutedAction = 'concentratedFire';
+            continue;
+        }
+        logAction(`(${targetX},${targetY}) へ集中砲撃を開始します。`);
+        for (const ship of availableWarships) {
+            if (ship.currentAmmo <= 0 || ship.currentFuel <= 0) continue;
+            ship.currentAmmo -= 1;
+            ship.currentFuel = Math.max(0, ship.currentFuel - 1);
+            logAction(`軍艦「${ship.name}」が (${targetX},${targetY}) に砲撃しました。`);
+            const monsterHit = monsters.find(m => m.x === targetX && m.y === targetY);
+            if (monsterHit) {
+                monsterHit.hp -= 1;
+                const monsterName = MONSTER_TYPES[monsterHit.typeId] ? MONSTER_TYPES[monsterHit.typeId].name : '怪獣';
+                if (monsterHit.hp <= 0) {
+                    handleMonsterDefeat(monsterHit, `${monsterName} は集中砲撃により討伐されました！`);
+                } else {
+                    logAction(`${monsterName} に命中！ (残り体力: ${monsterHit.hp})`);
+                }
+                continue;
+            }
+            const targetTile = map[targetY][targetX];
+            if (targetTile.terrain === 'mountain') {
+                logAction(`集中砲撃は山に着弾しましたが、被害はありませんでした。 (${targetX},${targetY})`);
+                continue;
+            }
+            if (targetTile.terrain === 'sea') {
+                if (targetTile.facility === 'port') {
+                    targetTile.facility = null;
+                    logAction(`集中砲撃により (${targetX},${targetY}) の港が破壊されました。`);
+                    continue;
+                }
+                const targetWarship = warships.find(w => w.x === targetX && w.y === targetY && w !== ship);
+                if (targetWarship && !targetWarship.isDispatched) {
+                    targetWarship.currentDurability -= 1;
+                    if (targetWarship.currentDurability <= 0) {
+                        targetWarship.currentDurability = 0;
+                        targetWarship.currentAmmo = 0;
+                        targetWarship.currentFuel = 0;
+                        logAction(`集中砲撃により軍艦「${targetWarship.name}」が撃沈されました！`);
+                    } else {
+                        logAction(`集中砲撃が軍艦「${targetWarship.name}」に命中！ (残り耐久: ${targetWarship.currentDurability})`);
+                    }
+                } else {
+                    logAction(`集中砲撃は海に着弾しました。 (${targetX},${targetY})`);
+                }
+            } else {
+                if (targetTile.facility === 'house') {
+                    population -= targetTile.pop;
+                    if (population < 0) population = 0;
+                }
+                targetTile.facility = null;
+                targetTile.enhanced = false;
+                targetTile.terrain = 'waste';
+                logAction(`集中砲撃により (${targetX},${targetY}) が破壊されました。`);
+            }
+        }
+        previousExecutedAction = 'concentratedFire';
     }
     else if (action === 'buildFarm') {
       if (tile && tile.terrain === 'plain' && money >= 100) {
@@ -1978,7 +2106,7 @@ const newWarship = {
         handleHouseOverwrite(tile);
         tile.facility = 'gun'; money -= 1200; tile.enhanced = false; // 強化状態もリセット
         logAction(`(${x},${y}) に砲台を建設しました`);
-        const guns = map.flat().filter(t => t.facility === 'gun').length;
+        const guns = getGunCount();
         checkAndCompleteMission('05', 1, 0, 1000,() => guns >= 3,'砲撃可能数が3以上になる');
       } else logAction(`(${x},${y}) の砲台建設は失敗しました（条件不適合または資金不足）`);
     }
@@ -2079,9 +2207,9 @@ const newWarship = {
         }
     }
 }
-    else if (action === 'bombard' || action === 'spreadBombard' || action === 'ppBombard') {
+    else if (action === 'bombard' || action === 'spreadBombard' || action === 'ppBombard' || action === 'randomBombard') {
       const count = task.count || 1;
-      const guns = map.flat().filter(t => t.facility === 'gun').length;
+      const guns = getGunCount();
       let costPerShot = 0;
       let errorRange = 1; // 砲撃の誤差範囲
       if (action === 'bombard') {
@@ -2093,33 +2221,45 @@ const newWarship = {
       } else if (action === 'ppBombard') {
           costPerShot = 10000000; // PP弾の価格を更新
           errorRange = 0; // 誤差なし
+      } else if (action === 'randomBombard') {
+          costPerShot = 500000;
+          errorRange = 0;
       }
 
       const usableGuns = Math.min(count, guns, Math.floor(money / costPerShot));
 
       if (usableGuns > 0) {
         let hits = 0;
+        let shotsFired = 0;
         for (let i = 0; i < usableGuns; i++) {
-          let dx = 0;
-          let dy = 0;
-          if (errorRange > 0) {
-            dx = Math.floor(Math.random() * (2 * errorRange + 1)) - errorRange;
-            dy = Math.floor(Math.random() * (2 * errorRange + 1)) - errorRange;
+          shotsFired++;
+          let tx = 0;
+          let ty = 0;
+          if (action === 'randomBombard') {
+            tx = Math.floor(Math.random() * SIZE);
+            ty = Math.floor(Math.random() * SIZE);
+          } else {
+            let dx = 0;
+            let dy = 0;
+            if (errorRange > 0) {
+              dx = Math.floor(Math.random() * (2 * errorRange + 1)) - errorRange;
+              dy = Math.floor(Math.random() * (2 * errorRange + 1)) - errorRange;
+            }
+            tx = x + dx;
+            ty = y + dy;
           }
-          const tx = x + dx;
-          const ty = y + dy;
 
           if (tx >= 0 && ty >= 0 && tx < SIZE && ty < SIZE) {
             const protectingFacility = getProtectingDefenseFacility(tx, ty); // 変更点
 
             if (protectingFacility) { // 防衛施設があった場合
-                if (action === 'ppBombard') { // PP弾だった場合
+                if (action === 'ppBombard' || action === 'randomBombard') { // PP弾・ランダム弾だった場合
                     protectingFacility.facility = null; // 防衛施設を破壊
                     protectingFacility.terrain = 'waste'; // 防衛施設の場所を荒地にする
                     protectingFacility.enhanced = false; // 強化状態もリセット
-                    logAction(`(${tx},${ty}) を守っていた防衛施設がPP弾により破壊されました！`);
-                    // その後、PP弾の効果を適用（既存の攻撃ロジックに流れる）
-                } else { // PP弾でなければ防衛施設が守る
+                    logAction(`(${tx},${ty}) を守っていた防衛施設が${getBombardTypeLabel(action)}により破壊されました！`);
+                    // その後、貫通弾の効果を適用（既存の攻撃ロジックに流れる）
+                } else { // 貫通弾でなければ防衛施設が守る
                     renderMap();
                     logAction(`砲撃は防衛施設により無効化されました (${tx},${ty})`);
                     turnTileEffects.push({ x: tx, y: ty, type: 'blue' });
@@ -2134,8 +2274,7 @@ const newWarship = {
                 const monsterName = MONSTER_TYPES[monsterHit.typeId] ? MONSTER_TYPES[monsterHit.typeId].name : '怪獣';
                 logAction(`砲撃が ${monsterName} に命中！ (残り体力: ${monsterHit.hp})`);
                 if (monsterHit.hp <= 0) {
-                    monsters = monsters.filter(m => m !== monsterHit);
-                    logAction(`${monsterName} が砲撃により討伐されました‼`);
+                    handleMonsterDefeat(monsterHit, `${monsterName} が砲撃により討伐されました‼`);
                 }
                 hits++; // 命中カウント
                 continue; // タイル破壊はスキップ
@@ -2198,7 +2337,11 @@ const newWarship = {
             logAction(`砲撃は領域外に着弾しました (${tx},${ty})`);
           }
         }
-        money -= hits * costPerShot; // 成功した砲撃の数だけ費用を引く
+        if (action === 'randomBombard') {
+          money -= shotsFired * costPerShot;
+        } else {
+          money -= hits * costPerShot; // 成功した砲撃の数だけ費用を引く
+        }
       } else {
         logAction(`砲撃は実行されませんでした。`);
       }
@@ -2238,8 +2381,7 @@ const newWarship = {
                             const monsterName = MONSTER_TYPES[monsterHit.typeId] ? MONSTER_TYPES[monsterHit.typeId].name : '怪獣';
                             logAction(`自爆により ${monsterName} (${nx},${ny}) は${damage}のダメージを受けました。残り体力: ${monsterHit.hp}`);
                             if (monsterHit.hp <= 0) {
-                                monsters = monsters.filter(m => m !== monsterHit);
-                                logAction(`${monsterName} は自爆に巻き込まれ討伐されました！`);
+                                handleMonsterDefeat(monsterHit, `${monsterName} は自爆に巻き込まれ討伐されました！`);
                             }
                         }
                     }
@@ -2271,7 +2413,7 @@ const newWarship = {
         }
     }
     else if (action === 'enhanceFacility') { // 設備強化
-        if (tile && (tile.facility === 'farm' || tile.facility === 'factory'|| tile.facility === 'oilRig') && !tile.enhanced && money >= 10000) {
+        if (tile && (tile.facility === 'farm' || tile.facility === 'factory'|| tile.facility === 'oilRig' || tile.facility === 'gun') && !tile.enhanced && money >= 10000) {
 tile.enhanced = true;
         money -= 10000;
         
@@ -2279,6 +2421,7 @@ tile.enhanced = true;
         if (tile.facility === 'farm') facilityName = '農場';
         else if (tile.facility === 'factory') facilityName = '工場';
         else if (tile.facility === 'oilRig') facilityName = '海底油田';
+        else if (tile.facility === 'gun') facilityName = '高効率砲台';
         logAction(`(${x},${y}) の${facilityName}が強化されました。`);
             checkAndCompleteMission('04', 1, 0, 1000, () => true, '工場または農場に設備強化を行う');
         } else {
@@ -2759,7 +2902,7 @@ if (turn >= 1000 && Math.random() < 0.001) { // 0.1% = 0.001
           const type = MONSTER_TYPES[typeId];
           
           // 3. 出現条件チェック (人口) と確率 (1%)
-          if (type.condition(population) && Math.random() < 0.01) {
+          if (type.condition(population, turn) && Math.random() < 0.01) {
               
               // 4. 出現場所の決定 (候補地からランダム)
               if (spawnCandidates.length === 0) break; 
@@ -2806,6 +2949,10 @@ if (turn >= 1000 && Math.random() < 0.001) { // 0.1% = 0.001
       
       const monsterType = MONSTER_TYPES[monster.typeId];
       if (!monsterType) continue; // 不明な怪獣はスキップ
+      if (monsterType.moneyPerTurn && monsterType.moneyPerTurn > 0) {
+          moneyChange += monsterType.moneyPerTurn;
+          logAction(`${monsterType.name} が${monsterType.moneyPerTurn}Gを生産しました。`);
+      }
 
       // 1. 移動処理 (アエロガロスは特別)
       let moveCount = 1;
@@ -2962,19 +3109,23 @@ if (turn >= 1000 && Math.random() < 0.001) { // 0.1% = 0.001
   }
 
 let gunCount = 0;
+let enhancedGunCount = 0;
 let defenseFacilityCount = 0;
 let portCount = 0;
 // マップ上の施設数をカウント
 map.forEach(row => {
     row.forEach(tile => {
-        if (tile.facility === 'gun') gunCount++;
+        if (tile.facility === 'gun') {
+            gunCount++;
+            if (tile.enhanced) enhancedGunCount++;
+        }
         else if (tile.facility === 'defenseFacility') defenseFacilityCount++;
         else if (tile.facility === 'port') portCount++;
     });
 });
 // 沈没していない軍艦（currentDurability > 0）の数をカウント
 const activeWarshipCount = warships.filter(ship => ship.currentDurability > 0).length;
-const facilityMaintenance = (gunCount * 600) + (defenseFacilityCount * 2000) + (portCount * 2500);
+const facilityMaintenance = (gunCount * 600) + (enhancedGunCount * 600) + (defenseFacilityCount * 2000) + (portCount * 2500);
 const warshipMaintenance = activeWarshipCount * 20000;
 let maintenanceCost = facilityMaintenance + warshipMaintenance;
 let maintenanceMultiplier = 1;
@@ -2984,7 +3135,7 @@ if (economicCrisisTurns > 0) {
 const actualMaintenanceCost = maintenanceCost * maintenanceMultiplier;
 if (actualMaintenanceCost > 0) {
     money -= actualMaintenanceCost;
-    let logMsg = `維持費 ${actualMaintenanceCost}G を資金から差し引きました。（砲台:${gunCount}、防衛施設:${defenseFacilityCount}、港:${portCount}、軍艦:${activeWarshipCount}）`;
+    let logMsg = `維持費 ${actualMaintenanceCost}G を資金から差し引きました。（砲台:${gunCount}（高効率:${enhancedGunCount}）、防衛施設:${defenseFacilityCount}、港:${portCount}、軍艦:${activeWarshipCount}）`;
     if (maintenanceMultiplier > 1) {
         logMsg += ` (経済危機により${maintenanceMultiplier}倍)`;
     }


### PR DESCRIPTION
### Motivation
- Introduce new bombardment options and concentrated fire tactics to diversify offensive gameplay and remote attacks.
- Add higher-tier monsters that generate income and grant defeat rewards, and support enhanced gun behavior for improved defense/maintenance modeling.
- Ensure bombardment interactions (including from other islands) properly handle random strikes, PP-like penetration, and defensive facilities.

### Description
- UI: added `ランダム弾砲撃` and `集中砲撃` options in `index.html` and exposed bombard options where appropriate.
- Bombardment: implemented `randomBombard` handling end-to-end including encoding for inter-island actions, sending/receiving logic, random target selection, cost per shot, and penetration behavior that destroys defense facilities; reused `getBombardTypeLabel` for human-friendly logs.
- Concentrated fire: added `concentratedFire` action that makes all eligible local warships fire at a selected tile, prevents immediate repeats, and auto-inserts a `delayAction` when queuing repeated concentrated fire to avoid abuse.
- Guns & enhancement: enhanced `getGunCount` to count enhanced guns as 3 shots, show enhanced gun names in tile info, allow enhancing `gun` via `enhanceFacility`, and include enhanced gun counts in maintenance cost calculations and logs.
- Monsters: extended `MONSTER_TYPES` with higher-tier monsters that provide `moneyPerTurn` and `defeatMoney`, applied per-turn income and defeat rewards, and added `handleMonsterDefeat` helper to centralize defeat reward logic and logging.
- Misc: multiple adjustments to bombard logic (mountain handling, error ranges), warship attack flows to call `handleMonsterDefeat`, inclusion of `randomBombard` in various validation paths, and assorted UI/queue display and queue-size protections.

### Testing
- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d1b85a4b048324b9408cc34ff5c148)